### PR TITLE
Turn of interrupts for local copies

### DIFF
--- a/RC_Rx_header_example/rc_rx.cpp
+++ b/RC_Rx_header_example/rc_rx.cpp
@@ -91,11 +91,12 @@ void init_rc_rx(){
 }
 
 void read_rc_rx(){
+  noInterrupts();
   CH1 = ((float)CH1_delta-(float)min_high_time)*100/(max_high_time-min_high_time);
   CH2 = ((float)CH2_delta-(float)min_high_time)*100/(max_high_time-min_high_time);
   CH3 = ((float)CH3_delta-(float)min_high_time)*100/(max_high_time-min_high_time);
   CH4 = ((float)CH4_delta-(float)min_high_time)*100/(max_high_time-min_high_time);
-
+  interrupts();
 }
 
 

--- a/RC_Rx_header_example_ver_0_2/rc_rx.cpp
+++ b/RC_Rx_header_example_ver_0_2/rc_rx.cpp
@@ -168,6 +168,7 @@ void init_rc_rx(){
 }
 
 void read_rc_rx(){
+  noInterrupts();
   CH1 = ((float)CH1_delta-(float)min_high_time)*100/(max_high_time-min_high_time);
   CH2 = ((float)CH2_delta-(float)min_high_time)*100/(max_high_time-min_high_time);
   CH3 = ((float)CH3_delta-(float)min_high_time)*100/(max_high_time-min_high_time);
@@ -175,7 +176,7 @@ void read_rc_rx(){
   CH5 = ((float)CH5_delta-(float)min_high_time)*100/(max_high_time-min_high_time);
   CH6 = ((float)CH6_delta-(float)min_high_time)*100/(max_high_time-min_high_time);
   CH7 = ((float)CH7_delta-(float)min_high_time)*100/(max_high_time-min_high_time);
-
+  interrupts();
 }
 
 


### PR DESCRIPTION
It is recommended to turn off interrupts before accessing the values of variables. In some cases data can be updated at the time of reading, the variable may return waste.

Amazing lib, It helped me a lot in a project.
Thank you!
